### PR TITLE
ENTNERO-4322: Update FlowInline to accept an optional object argument

### DIFF
--- a/yoflow/admin.py
+++ b/yoflow/admin.py
@@ -55,7 +55,7 @@ class FlowInline(GenericTabularInline):
         )
         return format_html('<a href="{}">{}</a>'.format(url, obj.pk))
 
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, object=None):
         return False
 
 


### PR DESCRIPTION
## JIRA-ID [ENTNERO-4322](https://teyaglobal.atlassian.net/browse/ENTNERO-4322)

Fix for 500 server error in django admin caused by Yoflow inline objects

[Cloudwatch logs](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/ecs$252FStaging1-Services$252Fstaging1-engage/log-events/staging1-engage$252Fstaging1-engage$252F5c973844-6f71-494c-8952-3c640d37dec0$3Fstart$3D2024-07-11T14$253A11$253A09.522Z)